### PR TITLE
Add Hugo image render hook

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -29,6 +29,7 @@ main {
 
 img {
     max-width: 100%;
+    height: auto;
 }
 
 #taxonomies {

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -2,14 +2,20 @@ locale = 'en-us'
 title = 'CDSE custom scripts <3'
 sectionPagesMenu = 'main'
 
-[markup]
-  [markup.highlight]
-    style = 'tokyonight-day'
+[markup.highlight]
+style = 'tokyonight-day'
+
+[markup.goldmark.parser]
+wrapStandAloneImageWithinParagraph = false
+
+[markup.goldmark.parser.attribute]
+block = true
+title = true
 
 [taxonomies]
-    type = 'types'
-    verification = 'verifications'
-    default = 'default'
-    domain = 'domains'
-    data-source = 'data-sources'
-    resolution = 'resolutions'
+type = 'types'
+verification = 'verifications'
+default = 'default'
+domain = 'domains'
+data-source = 'data-sources'
+resolution = 'resolutions'

--- a/content/script/sentinel-3/ulyssys_water_quality_viewer/index.md
+++ b/content/script/sentinel-3/ulyssys_water_quality_viewer/index.md
@@ -52,6 +52,7 @@ and
 By default, all pixels identified as "not water" (cloud, snow or land) are shown in true colour. All pixels identifed as water are coloured with an algorithm that evaluates chlorophyll and suspended sediment concentration together. This visualization can be compared to a GIS map with two raster layers, sediment on top and chlorophyll below. The sediment "layer" is semi-transparent and can cover the chlorophyll "layer". Just like clouds in the atmosphere, sediment in the water reduces transparency and obscures chlorophyll. Therefore water pixels with high sediment concentrations are coloured dark brown regardless of their chlorophyll concentration. Medium sediment concentrations are coloured wheat (light brown) with increasing transparency towards lower sediment concentrations. At low sediment concentrations the sediment "layer" is completely transparent. Below the semi-transparent sediment "layer", the chlorophyll concentration is visualized. High chlorophyll concentrations are marked in red, medium concentrations green, and low concentrations dark blue (see palette image below).
 
 ![Color legend of values](assets/palette.png)
+{width=500}
 
 By changing input parameters of the script it is also possible to:
 
@@ -178,6 +179,7 @@ In a document bibliography, please use the following citation:
 Zlinszky, A.; Padányi-Gulyás, G. Ulyssys Water Quality Viewer Technical Description Supplementary. Preprints 2020, 2020010386 (doi: 10.20944/preprints202001.0386.v1).
 
 ![Ulyssys Logo](assets/ulyssys_logo.png)
+{width=250}
 
 ## Description of representative images
 

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -1,0 +1,4 @@
+{{- $w := index .Attributes "width" -}}
+{{- $h := index .Attributes "height" -}}
+
+<img src="{{ .Destination | safeURL }}" alt="{{ .Text }}" {{ with $w }}width="{{ . }}"{{ end }} {{ with $h }}height="{{ . }}"{{ end }} {{ with .Title }}title="{{ . }}"{{ end }} loading="lazy">


### PR DESCRIPTION
Reads `width` and `height` values from Markdown attribute blocks. If no custom dimensions are set in Markdown, the attributes are omitted, leaving sizing up to CSS `(max-width: 100%; height: auto;)`.